### PR TITLE
Add query hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@types/react": "^16.9.36",
     "@types/react-dom": "^16.9.8",
+    "axios": "^0.19.2",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.21.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+axios.defaults.withCredentials = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 import axios from 'axios';
 
+export { useQuery } from './use-query';
+export { useQueryLater } from './use-query-later';
+
 axios.defaults.withCredentials = true;

--- a/src/use-query-later.ts
+++ b/src/use-query-later.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+type Data = any;
+
+type RequestState = {
+  isLoading: boolean;
+  isSuccessful: boolean;
+  hasError: boolean;
+  data: Data;
+};
+
+type ReturnValue = [RequestState, () => void];
+
+export const useQueryLater = (url: string): ReturnValue => {
+  const [isMakingRequest, setIsMakingRequest] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccessful, setIsSuccessful] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [data, setData] = useState<Data>(null);
+
+  const executeQuery = () => {
+    if (isSuccessful) {
+      setIsSuccessful(false);
+    }
+    if (hasError) {
+      setHasError(false);
+    }
+    setData(null);
+    setIsMakingRequest(true);
+  };
+
+  useEffect(() => {
+    const source = axios.CancelToken.source();
+
+    if (isMakingRequest) {
+      setIsLoading(true);
+
+      axios
+        .get(url, {
+          cancelToken: source.token,
+        })
+        .then(({ data }) => {
+          setIsMakingRequest(false);
+          setIsLoading(false);
+          setData(data);
+          setIsSuccessful(true);
+        })
+        .catch((err) => {
+          if (axios.isCancel(err)) {
+            return err;
+          }
+          setIsMakingRequest(false);
+          setIsLoading(false);
+          setHasError(true);
+        });
+    }
+
+    return () => source.cancel();
+  }, [isMakingRequest, url]);
+
+  return [{ isLoading, isSuccessful, hasError, data }, executeQuery];
+};

--- a/src/use-query.ts
+++ b/src/use-query.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+type UseQueryReturnValue = {
+  isLoading: boolean;
+  isSuccessful: boolean;
+  hasError: boolean;
+  data: any;
+};
+
+export const useQuery = (url: string): UseQueryReturnValue => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSuccessful, setIsSuccessful] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    const source = axios.CancelToken.source();
+
+    axios
+      .get(url, {
+        cancelToken: source.token,
+      })
+      .then(({ data }) => {
+        setIsLoading(false);
+        setData(data);
+        setIsSuccessful(true);
+      })
+      .catch((err) => {
+        if (axios.isCancel(err)) {
+          return err;
+        }
+        setIsLoading(false);
+        setHasError(true);
+      });
+
+    return () => source.cancel();
+  }, [url]);
+
+  return { isLoading, hasError, isSuccessful, data };
+};

--- a/src/use-query.ts
+++ b/src/use-query.ts
@@ -1,18 +1,20 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
-type UseQueryReturnValue = {
+type Data = any;
+
+type ReturnValue = {
   isLoading: boolean;
   isSuccessful: boolean;
   hasError: boolean;
-  data: any;
+  data: Data;
 };
 
-export const useQuery = (url: string): UseQueryReturnValue => {
+export const useQuery = (url: string): ReturnValue => {
   const [isLoading, setIsLoading] = useState(true);
   const [isSuccessful, setIsSuccessful] = useState(false);
   const [hasError, setHasError] = useState(false);
-  const [data, setData] = useState<any>(null);
+  const [data, setData] = useState<Data>(null);
 
   useEffect(() => {
     const source = axios.CancelToken.source();

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,6 +165,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -323,6 +330,13 @@ csstype@^2.2.0:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 debug@^2.6.9:
   version "2.6.9"
@@ -715,6 +729,13 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This merge adds `use-query.ts` and `use-query-later.ts` - two hooks for fetching data. The first one makes a request immediately (or after first render to be more precise) and the other one makes it when triggered by an `executeQuery`  function. Both of them return an object of states: `isLoading`, `isSuccessful`, `hasError` and `data`, in addition to this the `useQueryLater` hook also returns the function to trigger the query. The two values are returned as an array (of `tuple` type).

This merge also add axios as a dev dependency, since it's used to make the requests. And in order to allow setting cookies from the server for all requests the `axios.defaults.withCredentials = true` is added to `index.ts`.