### PR TITLE
Add mutation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple library that provides React hooks for making requests and accessing a b
 
 - [x] query hook to instantly make a GET request to a given url
 - [x] query hook to make a GET request to a given url when an execution function is called
-- [ ] mutation hook to make a POST/PUT/DELETE request to a given url when an execution function is called
+- [x] mutation hook to make a POST/PUT/DELETE request to a given url when an execution function is called
 - [ ] tests
 - [ ] publish to npm
 - [ ] caching data?

--- a/README.md
+++ b/README.md
@@ -58,8 +58,35 @@ function QueryWhenISaySo() {
 }
 ```
 
----
+#### useMutation:
+
+```javascript
+import { useMutation } from 'react-request-hooks';
+
+function MutateWhenISaySo() {
+const [{ isLoading, isSuccessful, hasError, data }, executeMutation] = useMutation({
+  method: 'POST';
+  url:'https://some-cool-url',
+  data: {
+    firstName: 'Cool',
+    lastName: 'McCool'
+  }; //'data' is optional
+  headers: {
+    {'X-Requested-With': 'XMLHttpRequest'}
+  }, //'headers' is optional
+  urlParams: {
+    someParam: 'Param'
+  } //'urlParams' is optional
+});
+
+  return (
+    <>
+      <button onClick={executeMutation}>Create new item in database!</button>
+      {isLoading && <SomeCoolLoader />}
+      // and so on
+    </>
+  );
+}
+```
 
 ---
-
-Made with support and encouragement from [Lo Axhamre](https://github.com/axhamre).

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ import axios from 'axios';
 
 export { useQuery } from './use-query';
 export { useQueryLater } from './use-query-later';
+export { useMutation } from './use-mutation';
 
 axios.defaults.withCredentials = true;

--- a/src/use-mutation.ts
+++ b/src/use-mutation.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+type requestParams = {
+  method: 'POST' | 'PUT' | 'DELETE';
+  url: string;
+  data?: any;
+  headers?: Record<string, any>;
+  urlParams?: Record<string, any>;
+};
+
+type Data = any;
+
+type RequestState = {
+  isLoading: boolean;
+  isSuccessful: boolean;
+  hasError: boolean;
+  data: Data;
+};
+
+type ReturnValue = [RequestState, () => void];
+
+export const useMutation = ({
+  method,
+  url,
+  data: reqData,
+  headers,
+  urlParams,
+}: requestParams): ReturnValue => {
+  const [shouldMakeRequest, setShouldMakeRequest] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [isSuccessful, setIsSuccessful] = useState(false);
+  const [data, setData] = useState<Data>(null);
+
+  const executeMutation = () => {
+    setIsSuccessful(false);
+    setHasError(false);
+    setData(null);
+    setShouldMakeRequest(true);
+  };
+
+  useEffect(() => {
+    const source = axios.CancelToken.source();
+
+    if (shouldMakeRequest) {
+      setIsLoading(true);
+
+      axios({
+        method,
+        url,
+        data: reqData,
+        params: urlParams,
+        cancelToken: source.token,
+        headers,
+      })
+        .then(({ data }) => {
+          setShouldMakeRequest(false);
+          setIsLoading(false);
+          setData(data);
+          setIsSuccessful(true);
+        })
+        .catch((err) => {
+          if (axios.isCancel(err)) {
+            return err;
+          }
+          setShouldMakeRequest(false);
+          setIsLoading(false);
+          setHasError(true);
+        });
+    }
+
+    return () => source.cancel();
+  }, [shouldMakeRequest, method, url, reqData, urlParams, headers]);
+
+  return [{ isLoading, hasError, isSuccessful, data }, executeMutation];
+};


### PR DESCRIPTION
This merge adds `use-mutation.ts` - which exports a hook for mutation data, i.e. to perform `POST`, `PUT` and `DELETE` request (I'm starting with the most basic request methods). This hook returns an array of tuple type, with the first value being an object with states `isLoading`, `isSuccessful`, `hasError` and `data`; and the second value being the function to trigger the request. Required parameters to this hook are `method`, which can be any of values `'POST' | 'PUT' | 'DELETE'`, and `url` (which is a string). Optional parameters are (so far) `data`, `headers` and `urlParams`.

The `useMutation` hook is exported from `index.ts` and `README.md` is updated with an example and with checking `mutation hook` off the roadmap list.